### PR TITLE
fix : 학습 세션 완료시 status 로직 수정

### DIFF
--- a/src/hooks/useChapterHandler.ts
+++ b/src/hooks/useChapterHandler.ts
@@ -14,11 +14,7 @@ export const useChapterHandler = () => {
     try {
       setConnectingChapter(chapterId);
       await API.post(`/progress/chapters/${chapterId}`);
-      // 추가: 학습 시작 시 status를 'study'로 업데이트
-      await API.post(`/progress/chapters/${chapterId}/lessons`, {
-        lesson_ids: lessonIds,
-        status: 'study',
-      });
+      // status를 'study'로 바꾸는 API 호출 부분 삭제
       try {
         const response = await API.get<{ success: boolean; data: { ws_urls: string[], lesson_mapper: { [key: string]: string } } }>(`/ml/deploy/${chapterId}`);
         if (response.data.success && response.data.data.ws_urls) {

--- a/src/pages/Chapters.tsx
+++ b/src/pages/Chapters.tsx
@@ -51,11 +51,7 @@ const Chapters = () => {
     }
 
     await API.post(`/progress/chapters/${chapter.id}`);
-    // 추가: 학습 시작 시 status를 'study'로 업데이트
-    await API.post(`/progress/chapters/${chapter.id}/lessons`, {
-      lesson_ids: lessonIds,
-      status: 'study',
-    });
+    // status를 'study'로 바꾸는 API 호출 부분 삭제
     await API.post('/progress/lessons/events', { lesson_ids: lessonIds });
     navigate(path);
   };

--- a/src/pages/LearnSession.tsx
+++ b/src/pages/LearnSession.tsx
@@ -516,20 +516,18 @@ const LearnSession = () => {
     }
   }, [lessons]);
 
-  if (sessionComplete) // 모든 내용이 완료 된 경우
-  {
-    checkBadges("");
-    navigate(`/complete/chapter/${chapterId}/${1}`);
-  }
-
-  // sessionComplete 시 소켓 연결 해제, 동시에 챕터 단위 진행도 업데이트
+  // 세션 완료 시 레슨 status 업데이트, 뱃지 체크, navigate를 순차적으로 처리
   useEffect(() => {
     if (sessionComplete) {
       disconnectWebSockets();
       API.post(`/progress/chapters/${chapterId}/lessons`,
-        { lesson_ids: studyListRef.current, status: "study" })
+        { lesson_ids: lessons.map(l => l.id), status: "study" })
+        .then(() => {
+          checkBadges("");
+          navigate(`/complete/chapter/${chapterId}/${1}`);
+        });
     }
-  }, [sessionComplete]);
+  }, [sessionComplete, lessons, chapterId, navigate, checkBadges]);
 
   //===============================================
 


### PR DESCRIPTION
무한 리렌더(Too many re-renders) 버그 수정
이전:
if (sessionComplete) { ... }가 컴포넌트 본문에 있어 무한 navigate/렌더링이 발생, 후처리 로직이 꼬임
수정:
sessionComplete 후처리(레슨 status 업데이트, 뱃지 체크, navigate)는 useEffect에서 한 번만 실행되도록 변경